### PR TITLE
feat: Add ability to ignore by path

### DIFF
--- a/src/ExpectedObjects.Specs/ExclusionSpecs.cs
+++ b/src/ExpectedObjects.Specs/ExclusionSpecs.cs
@@ -1,4 +1,6 @@
-﻿using ExpectedObjects.Specs.TestTypes;
+﻿using System;
+using System.Collections.Generic;
+using ExpectedObjects.Specs.TestTypes;
 using Machine.Specifications;
 
 namespace ExpectedObjects.Specs
@@ -30,6 +32,115 @@ namespace ExpectedObjects.Specs
             Because of = () => _results = _expected.Equals(_actual);
 
             It should_ignore_differences_in_property = () => _results.ShouldBeTrue();
+        }
+
+        [Subject("Ignore")]
+        public class when_excluding_a_property_by_string_path
+        {
+            static ExpectedObject _expected;
+            static ComplexType _actual;
+            static bool _results;
+
+            Establish context = () =>
+            {
+                _expected = new ComplexType
+                {
+                    StringProperty = "level 1",
+                    TypeWithString = new TypeWithString {StringProperty = "test"}
+                }.ToExpectedObject(ctx => ctx.Ignore("ComplexType.TypeWithString.StringProperty"));
+
+                _actual = new ComplexType
+                {
+                    StringProperty = "level 1",
+                    TypeWithString = new TypeWithString {StringProperty = "different"}
+                };
+            };
+
+            Because of = () => _results = _expected.Equals(_actual);
+
+            It should_ignore_differences_in_property = () => _results.ShouldBeTrue();
+        }
+
+        [Subject("Ignore")]
+        public class when_excluding_a_list_property
+        {
+            static ExpectedObject _expected;
+            static TypeWithElementList _actual;
+            static bool _results;
+            static Exception _exception;
+
+            Establish context = () =>
+            {
+                _expected = new TypeWithElementList
+                {
+                    Elements = new List<Element>
+                    {
+                        new Element
+                        {
+                            Data = "value"
+                        }
+                    }
+                }.ToExpectedObject(ctx => ctx.Ignore(x => x.Elements[0].Id));
+
+                _actual = new TypeWithElementList
+                {
+                    Id = 1,
+                    Elements = new List<Element>
+                    {
+                        new Element
+                        {
+                            Id = 1,
+                            Data = "value"
+                        }
+                    }
+                };
+            };
+
+            Because of = () => _exception = Catch.Exception(() => _expected.ShouldMatch(_actual));
+
+            It should_not_ignore_the_same_named_property_on_containing_element = () => _exception.ShouldNotBeNull();
+        }
+
+        [Subject("Ignore")]
+        public class when_excluding_all_properties_matching_path
+        {
+            static ExpectedObject _expected;
+            static TypeWithElementList _actual;
+            static bool _results;
+            static Exception _exception;
+
+            Establish context = () =>
+            {
+                _expected = new TypeWithElementList
+                {
+                    Id = 1,
+                    Elements = new List<Element>
+                    {
+                        new Element
+                        {
+                            Id = 1,
+                            Data = "value"
+                        }
+                    }
+                }.ToExpectedObject(ctx => ctx.Ignore("Id"));
+
+                _actual = new TypeWithElementList
+                {
+                    Id = 2,
+                    Elements = new List<Element>
+                    {
+                        new Element
+                        {
+                            Id = 2,
+                            Data = "value"
+                        }
+                    }
+                };
+            };
+
+            Because of = () => _exception = Catch.Exception(() => _expected.ShouldMatch(_actual));
+
+            It should_ignore_matching_properties = () => _exception.ShouldBeNull();
         }
 
         [Subject("Ignore")]

--- a/src/ExpectedObjects.Specs/TestTypes/Element.cs
+++ b/src/ExpectedObjects.Specs/TestTypes/Element.cs
@@ -1,0 +1,8 @@
+﻿namespace ExpectedObjects.Specs.TestTypes
+{
+    public class Element
+    {
+        public int Id { get; set; }
+        public string Data { get; set; }
+    }
+}

--- a/src/ExpectedObjects.Specs/TestTypes/TypeWithElementList.cs
+++ b/src/ExpectedObjects.Specs/TestTypes/TypeWithElementList.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace ExpectedObjects.Specs.TestTypes
+{
+    public class TypeWithElementList
+    {
+        public int Id { get; set; }
+        public List<Element> Elements { get; set; }
+    }
+}

--- a/src/ExpectedObjects/ConfigurationContext.cs
+++ b/src/ExpectedObjects/ConfigurationContext.cs
@@ -118,9 +118,28 @@ namespace ExpectedObjects
 
             while (memberExpression != null)
             {
-                var propertyName = memberExpression.Member.Name;
-                members.Push(propertyName);
-                memberExpression = memberExpression.Expression as MemberExpression;
+                if (memberExpression.Expression.NodeType == ExpressionType.Call)
+                {
+                    var propertyName = memberExpression.Member.Name;
+
+                    var methodCallExpression = memberExpression.Expression as MethodCallExpression;
+                    if (methodCallExpression.Method.Name == "get_Item")
+                    {
+                        members.Push($"{((MemberExpression)methodCallExpression.Object).Member.Name}[{methodCallExpression.Arguments[0]}].{propertyName}");
+                    }
+
+                    memberExpression = memberExpression.Expression as MemberExpression; 
+                }
+                else
+                {
+                    var propertyName = memberExpression.Member.Name;
+                    members.Push(propertyName);
+                    memberExpression = memberExpression.Expression as MemberExpression;    
+                }
+
+                
+
+                
             }
 
             return string.Join(".", members.ToArray());

--- a/src/ExpectedObjects/ConfigurationContextExtensions.cs
+++ b/src/ExpectedObjects/ConfigurationContextExtensions.cs
@@ -54,5 +54,16 @@ namespace ExpectedObjects
             configurationContext.Member(memberExpression).UsesComparison(Expect.Ignored());
             return configurationContext;
         }
+
+        /// <summary>
+        ///     Ignores the specified member in comparisons.
+        /// </summary>
+        /// <param name="memberPath">The path to the ignored member</param>
+        /// <returns></returns>
+        public static IConfigurationContext Ignore(this IConfigurationContext configurationContext, string memberPath)
+        {
+            ((IMemberConfigurationContext)configurationContext).ConfigureMember(memberPath, Expect.Ignored());
+            return configurationContext;
+        }
     }
 }

--- a/src/ExpectedObjects/EqualityComparer.cs
+++ b/src/ExpectedObjects/EqualityComparer.cs
@@ -112,10 +112,15 @@ namespace ExpectedObjects
 
         IComparison GetMemberStrategy(string path)
         {
-            if (_ignoreTypeInformation)
+            var pathTokens = path.Split('.');
+
+            if (_ignoreTypeInformation && pathTokens.Length > 1)
             {
                 var subPath = string.Join(".", path.Split('.').Skip(1));
-                return _configurationContext.MemberStrategies.Where(s => s.Key.EndsWith(subPath)).Select(s => s.Value).FirstOrDefault();
+                
+                return _configurationContext.MemberStrategies
+                    .Where(s => subPath.EndsWith(s.Key.Substring(s.Key.IndexOf('.') + 1)))
+                    .Select(s => s.Value).FirstOrDefault();
             }
 
             IComparison comparison;


### PR DESCRIPTION
This feature adds the ability to ignore members by member path
in addition to the currently supported functionality of ignoring
members using an expression.

Fixes #24